### PR TITLE
Lower cube float height relative to walls

### DIFF
--- a/src/game/render.js
+++ b/src/game/render.js
@@ -82,8 +82,8 @@ export function render(state, ctx, cv, paused=false){
       const e=b.extra;
       const cubeSize = spriteW * (e.sizeMul||0.4);
       const x = b.x + shakeX;
-      // place cubes lower: base starts 200px from bottom
-      const baseFromBottom = 200;
+      // place cubes much lower: just above ground level
+      const baseFromBottom = 50;  // Very low, just 50px from bottom
       const yCenter = (H - baseFromBottom) - cubeSize/2 + shakeY;
       drawCube3D(ctx, x, yCenter, cubeSize, e.rot, e.color);
       ctx.fillStyle='#000'; ctx.fillRect(x - cubeSize/2, yCenter - cubeSize/2 - 8, cubeSize, 6);


### PR DESCRIPTION
Adjust cube floating height to be much lower and closer to the ground, ensuring they do not float higher than walls.

---
<a href="https://cursor.com/background-agent?bcId=bc-4530492f-9461-40b2-847a-2528debebbf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4530492f-9461-40b2-847a-2528debebbf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

